### PR TITLE
Update plotting.py to match gene name exactly

### DIFF
--- a/adobo/plotting.py
+++ b/adobo/plotting.py
@@ -699,14 +699,14 @@ adobo.bio.cell_type_predict has not been called yet.')
             pl_idx += 1
         # plot genes
         for gene in genes:
-            if not np.any(item['data'].index.str.match(gene)):
+            if not np.any(item['data'].index.str.fullmatch(gene)):
                 m = '"%s" was not found in the gene expression matrix' % gene
                 raise Exception(m)
-            if np.sum(item['data'].index.str.match(gene)) > 1:
+            if np.sum(item['data'].index.str.fullmatch(gene)) > 1:
                 raise Exception(
                     'Multiple genes found with the name "%s"' % gene)
             #ge = item['data'].loc[gene, :]
-            ge = item['data'][item['data'].index.str.match(gene)]
+            ge = item['data'][item['data'].index.str.fullmatch(gene)]
             cmap = sns.cubehelix_palette(as_cmap=True)
             po = aa[pl_idx].scatter(E.iloc[:, 0], E.iloc[:, 1], s=marker_size,
                                     c=ge.values[0], cmap=cmap)


### PR DESCRIPTION
When inputting gene names that begin with the same characters (e.g. FLT1 and FLT1P1) using `item['data'].index.str.match(gene) `returns more than one gene, which raises exception. 
Changing to `str.fullmatch(gene)`, requires complete match of the input gene name, hence preventing ambiguity.